### PR TITLE
DO NOT MERGE: Add link to encoding guidance

### DIFF
--- a/source/documentation/publish_and_manage_data/gemini_and_iso_19139_metadata.md
+++ b/source/documentation/publish_and_manage_data/gemini_and_iso_19139_metadata.md
@@ -39,7 +39,7 @@ There are two key differences with GEMINI compared to ISO 19139:
 * the resource type will be 'dataset', 'series' or 'service' (not 'nonGeographicDataset')
 * the spatial extent of the data is indicated using a Geographic Bounding Box
 
-Detailed guidance on GEMINI is provided: [UK GEMINI Encoding Guidance](xx)
+For more information see the [UK GEMINI Encoding Guidance](http://data.gov.uk/library/uk-gemini-encoding-guidance).
 
 ISO 19139 and GEMINI2 are similar, but you should validate using the GEMINI2 schematron in your GIS before publishing to data.gov.uk, to spot any issues earlier in the chain.
 


### PR DESCRIPTION
Former docs link to an old page, which no longer exists.

@brucebolt - is there a replacement for this page or should we remove entirely?