### PR TITLE
Remove broken API links and odd formatting

### DIFF
--- a/source/documentation/get_data/api_documentation.md
+++ b/source/documentation/get_data/api_documentation.md
@@ -14,14 +14,10 @@ For example calls using curl and parameters see the [CKAN API documentation](htt
 
 This table lists the parameters and returns with example URLs.
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
 | Parameter                         | Returns                            | Example URL                                                              |
 |-----------------------------------|------------------------------------|--------------------------------------------------------------------------|
 | `package_list`                    | List of datasets                   | https://data.gov.uk/api/action/package_list                              |
 | `package_show?id=<PUBLISHER-NAME>` | Information about a single dataset | https://data.gov.uk/api/action/package_show?id=cabinet-office-energy-use |
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
 
 ### Search datasets
 
@@ -29,14 +25,10 @@ Use `package_search` to search datasets.
 
 SOLR provides the parameters for search calls. For example parameters, see the [SOLR documentation](https://lucene.apache.org/solr/guide/7_6/common-query-parameters.html).
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
 | Parameter | Action          | Example URL                                                                          |
 |-----------|-----------------|--------------------------------------------------------------------------------------|
 | `q`       | Free text query | https://data.gov.uk/api/action/package_search?q=fish                                 |
 | `fq`      | Data by field   | https://data.gov.uk/api/action/package_search?fq=publisher:peterborough-city-council |
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
 
 Remember to escape these URLs. Most browsers will escape these automatically when you click on these example links, but some clients, such as Python, will mostly need them URL encoded (spaces to `%20` etc). And on the command-line remember to quote the whole URL, for example use single quotes:
 
@@ -48,16 +40,10 @@ curl 'https://data.gov.uk/api/action/package_search?fq=res_url:"http://opendatac
 
 Data.gov.uk uses CKAN `organizations` to store what is shown as ‘publishers’ on the frontend.
 
-<div style="height:1px;font-size:1px;">&nbsp;</div>
-
 | Parameter                                                  | Returns                               | Example URL                                                                                                          |
 |------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------------|
 | `organization_list`                                        | List of publishers                    | https://data.gov.uk/api/action/organization_list`                                                                    |
 | `organization_show?id=<PUBLISHER-NAME>`                    | Information about a single publisher  | https://data.gov.uk/api/action/organization_show?id=cabinet-office&include_datasets=false                            |
-| `group_tree`                                               | Organisation hierarchy tree           | https://data.gov.uk/api/action/group_tree?type=organization                                                          |
-| `group_tree_section?type=organization&id=<PUBLISHER-NAME>` | Hierarchy below a single organisation | https://data.gov.uk/api/action/group_tree_section?type=organization&id=department-for-business-innovation-and-skills |
-
-<div style="height:1px;font-size:1px;">&nbsp;</div>
 
 ## Send a data request
 


### PR DESCRIPTION
Removes odd instances of HTML in the docs source code, and removes
the `/api/action/group_tree` and `/api/action/group_tree_section` methods
from the documentation, as they don't appear to ever have worked.