### PR TITLE
Revert "Remove broken API links and odd formatting"

### DIFF
--- a/source/documentation/get_data/api_documentation.md
+++ b/source/documentation/get_data/api_documentation.md
@@ -14,10 +14,14 @@ For example calls using curl and parameters see the [CKAN API documentation](htt
 
 This table lists the parameters and returns with example URLs.
 
+<div style="height:1px;font-size:1px;">&nbsp;</div>
+
 | Parameter                         | Returns                            | Example URL                                                              |
 |-----------------------------------|------------------------------------|--------------------------------------------------------------------------|
 | `package_list`                    | List of datasets                   | https://data.gov.uk/api/action/package_list                              |
 | `package_show?id=<PUBLISHER-NAME>` | Information about a single dataset | https://data.gov.uk/api/action/package_show?id=cabinet-office-energy-use |
+
+<div style="height:1px;font-size:1px;">&nbsp;</div>
 
 ### Search datasets
 
@@ -25,10 +29,14 @@ Use `package_search` to search datasets.
 
 SOLR provides the parameters for search calls. For example parameters, see the [SOLR documentation](https://lucene.apache.org/solr/guide/7_6/common-query-parameters.html).
 
+<div style="height:1px;font-size:1px;">&nbsp;</div>
+
 | Parameter | Action          | Example URL                                                                          |
 |-----------|-----------------|--------------------------------------------------------------------------------------|
 | `q`       | Free text query | https://data.gov.uk/api/action/package_search?q=fish                                 |
 | `fq`      | Data by field   | https://data.gov.uk/api/action/package_search?fq=publisher=peterborough-city-council |
+
+<div style="height:1px;font-size:1px;">&nbsp;</div>
 
 Remember to escape these URLs. Most browsers will escape these automatically when you click on these example links, but some clients, such as Python, will mostly need them URL encoded (spaces to `%20` etc). And on the command-line remember to quote the whole URL, for example use single quotes:
 
@@ -40,10 +48,14 @@ curl 'https://data.gov.uk/api/action/package_search?fq=publisher=peterborough-ci
 
 Data.gov.uk uses CKAN `organizations` to store what is shown as ‘publishers’ on the frontend.
 
+<div style="height:1px;font-size:1px;">&nbsp;</div>
+
 | Parameter                                                  | Returns                               | Example URL                                                                                                          |
 |------------------------------------------------------------|---------------------------------------|----------------------------------------------------------------------------------------------------------------------|
 | `organization_list`                                        | List of publishers                    | https://data.gov.uk/api/action/organization_list                                                                    |
 | `organization_show?id=<PUBLISHER-NAME>`                    | Information about a single publisher  | https://data.gov.uk/api/action/organization_show?id=cabinet-office&include_datasets=false                            |
+
+<div style="height:1px;font-size:1px;">&nbsp;</div>
 
 ## Send a data request
 


### PR DESCRIPTION
This partially reverts commit 021164e186edc0952c61611a6d49ee93d3ffb60b.

Without this, the tables don't render correctly when deployed.

See https://guidance.data.gov.uk/get_data/api_documentation/ for examples of tables not rendered correctly.