### PR TITLE
Add text about fields being publicly available

### DIFF
--- a/source/documentation/publish_and_manage_data/harvest_data.md
+++ b/source/documentation/publish_and_manage_data/harvest_data.md
@@ -2,6 +2,8 @@
 
 To use the data.gov.uk harvester, you must publish the datasets on the internet and then set up the harvester.
 
+Metadata fields from harvested datasets will be publicly available to users - including (where provided to us) personal information such as contact details for responsible parties. 
+
 1. Create a metadata record for the data.
 1. Publish the metadata record in a supported format.
 1. Set up the harvester.


### PR DESCRIPTION
Adds a note to publishers that any harvested fields will be publicly available. 

[Trello card](https://trello.com/c/kKEax9Lp/1372-1-add-warning-to-datagovuk-publishers-about-contact-data)