### PR TITLE
Downgrading ffi due to known bug which stops Middleman rendering

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
     execjs (2.7.0)
     fast_blank (1.0.0)
     fastimage (2.2.0)
-    ffi (1.13.1)
+    ffi (1.12.2)
     govuk_tech_docs (2.0.13)
       activesupport
       chronic (~> 0.10.2)


### PR DESCRIPTION
This is a known bug which stops Middleman from rendering correctly. Need to have visibility via Middleman to check the accessibility statement is set up. 