### PR TITLE
Change fancy quote to single quote

### DIFF
--- a/source/documentation/get_data/api_documentation.md
+++ b/source/documentation/get_data/api_documentation.md
@@ -41,7 +41,7 @@ SOLR provides the parameters for search calls. For example parameters, see the [
 Remember to escape these URLs. Most browsers will escape these automatically when you open these example links, but some clients, such as Python, will mostly need them URL encoded (spaces to `%20` etc). And on the command-line remember to quote the whole URL, for example use single quotes:
 
 ```
-curl 'https://data.gov.uk/api/action/package_search?fq=publisher=peterborough-city-council’
+curl 'https://data.gov.uk/api/action/package_search?fq=publisher=peterborough-city-council'
 ```
 
 ### Get publisher information


### PR DESCRIPTION
## What

Changed a fancy quote `’` to a single quote `'`.

## Why 
Changing this fancy quote to a single quote will help people who copy and paste the command.