### PR TITLE
updating accessibility statement to reflect March 2021 timeline for fixes

### DIFF
--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -87,9 +87,9 @@ We used manual and automated tests to look for issues such as:
 
 ## What we’re doing to improve accessibility
 
-We plan to fix the accessibility issues in the content by the end of 2020.
+We plan to fix the accessibility issues in the content by the end of March 2021.
 
-We plan to fix the other accessibility issues by [updating our Technical Documentation Template by the end of 2020](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
+We plan to fix the other accessibility issues by [updating our Technical Documentation Template by the end of March 2021](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
 
 This statement was prepared on 15 September 2020.
 

--- a/source/accessibility-statement.html.md.erb
+++ b/source/accessibility-statement.html.md.erb
@@ -91,6 +91,6 @@ We plan to fix the accessibility issues in the content by the end of March 2021.
 
 We plan to fix the other accessibility issues by [updating our Technical Documentation Template by the end of March 2021](https://tdt-documentation.london.cloudapps.digital/accessibility#using-the-technical-documentation-template-for-your-own-documentation).
 
-This statement was prepared on 15 September 2020.
+This statement was prepared on 15 September 2020 and updated on 30 December 2020.
 
 This website was last tested in September 2020. The test was carried out by the technical writing team at GDS. We used the [WAVE Web Accessibility Evaluation Tool](https://wave.webaim.org/) and a checklist we created with the help of the GDS accessibility team. We tested a sample page from the site.


### PR DESCRIPTION
Updated the date for fixing the Tech Docs Template accessibility issues from “end of December 2020” to “end of March 2021”. As a result of resourcing pressures and re-prioritisation this year, it’s taking longer than we hoped to arrange developer and designer resources to fix the accessibility issues.
