### PR TITLE
Add information about organisations that can publish

### DIFF
--- a/source/documentation/publish_and_manage_data/publish_and_manage_data.md
+++ b/source/documentation/publish_and_manage_data/publish_and_manage_data.md
@@ -1,5 +1,7 @@
 # Publish and manage datasets
 
+Central government, local authorities and public bodies can publish on data.gov.uk.
+
 Data.gov.uk does not host datasets. Instead, you must first publish the dataset (or supporting document) on your organisation’s website or on GOV.UK.
 
 You can then add the dataset to data.gov.uk, which will display a description and a link to the dataset.


### PR DESCRIPTION
Adds information about what type of organisation can publish on data.gov.uk, consistent with https://data.gov.uk/about