### PR TITLE
Remove allow list from Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,3 @@ updates:
     directory: /
     schedule:
       interval: daily
-    allow:
-      # Internal gems
-      - dependency-name: "govuk*"
-        dependency-type: direct
-      # Framework gems
-      - dependency-name: activesupport
-        dependency-type: direct
-      - dependency-name: middleman
-        dependency-type: direct
-      - dependency-name: redcarpet
-        dependency-type: direct


### PR DESCRIPTION
Trello card: https://trello.com/c/DuA0q9Ck/2966-remove-allow-lists-from-dependabot-configs-2