### PR TITLE
Fix link in API documentation

### DIFF
--- a/source/documentation/get_data/api_documentation.md
+++ b/source/documentation/get_data/api_documentation.md
@@ -23,17 +23,17 @@ This table lists the parameters and returns with example URLs.
 
 Use `package_search` to search datasets.
 
-SOLR provides the parameters for search calls. For example parameters, see the [SOLR documentation](https://lucene.apache.org/solr/guide/7_6/common-query-parameters.html).
+SOLR provides the parameters for search calls. For example parameters, see the [SOLR documentation](https://lucene.apache.org/solr/guide/7_6/common-query-parameters.html). 
 
 | Parameter | Action          | Example URL                                    |
 |-----------|-----------------|------------------------------------------------|
 | # `q`     | Free text query | https://data.gov.uk/api/action/package_search?q=fish |
-| # `fq`    | Data by field   | https://data.gov.uk/api/action/package_search?fq=publisher=peterborough-city-council |
+| # `fq`    | Data by field   | https://ckan.publishing.service.gov.uk/api/action/package_search?fq=organization:peterborough-city-council |
 
 Remember to escape these URLs. Most browsers will escape these automatically when you open these example links, but some clients, such as Python, will mostly need them URL encoded (spaces to `%20` etc). And on the command-line remember to quote the whole URL, for example use single quotes:
 
 ```
-curl 'https://data.gov.uk/api/action/package_search?fq=publisher=peterborough-city-council'
+curl 'https://ckan.publishing.service.gov.uk/api/action/package_search?fq=organization:peterborough-city-council'
 ```
 
 ### Get publisher information

--- a/source/documentation/get_data/api_documentation.md
+++ b/source/documentation/get_data/api_documentation.md
@@ -23,7 +23,7 @@ This table lists the parameters and returns with example URLs.
 
 Use `package_search` to search datasets.
 
-SOLR provides the parameters for search calls. For example parameters, see the [SOLR documentation](https://lucene.apache.org/solr/guide/7_6/common-query-parameters.html). 
+SOLR provides the parameters for search calls. For example parameters, see the [SOLR documentation](https://lucene.apache.org/solr/guide/7_6/common-query-parameters.html).
 
 | Parameter | Action          | Example URL                                    |
 |-----------|-----------------|------------------------------------------------|

--- a/source/documentation/get_data/api_documentation.md
+++ b/source/documentation/get_data/api_documentation.md
@@ -28,12 +28,12 @@ SOLR provides the parameters for search calls. For example parameters, see the [
 | Parameter | Action          | Example URL                                    |
 |-----------|-----------------|------------------------------------------------|
 | # `q`     | Free text query | https://data.gov.uk/api/action/package_search?q=fish |
-| # `fq`    | Data by field   | https://ckan.publishing.service.gov.uk/api/action/package_search?fq=organization:peterborough-city-council |
+| # `fq`    | Data by field   | https://data.gov.uk/api/action/package_search?fq=organization:peterborough-city-council |
 
 Remember to escape these URLs. Most browsers will escape these automatically when you open these example links, but some clients, such as Python, will mostly need them URL encoded (spaces to `%20` etc). And on the command-line remember to quote the whole URL, for example use single quotes:
 
 ```
-curl 'https://ckan.publishing.service.gov.uk/api/action/package_search?fq=organization:peterborough-city-council'
+curl 'https://data.gov.uk/api/action/package_search?fq=organization:peterborough-city-council'
 ```
 
 ### Get publisher information


### PR DESCRIPTION
There seems to be a bug with some calls using https://ckan.publishing.service.gov.uk/api/action/package_search?fq=publisher%3D[whatever], where results are returned for more than one publisher. 

The new link works, returning results from that single publisher.