### PR TITLE
Updated various guidance pages

### DIFF
--- a/source/documentation/publish_and_manage_data/add_data.md
+++ b/source/documentation/publish_and_manage_data/add_data.md
@@ -1,6 +1,6 @@
 # Add datasets manually
 
-If you do not want to [automatically harvest datasets](../harvest_data), you can add a dataset to data.gov.uk using an online form. You must submit one form per dataset.
+If you do not want to [automatically harvest datasets](../harvest_data), you can add a dataset to data.gov.uk manually.
 
 >You cannot use the form for publishing INSPIRE/Location data. See the guidance on [harvesting INSPIRE data](../inspire) for more information.
 
@@ -14,9 +14,9 @@ Sign into the [Data Publisher](https://ckan.publishing.service.gov.uk/).
 
 You can submit 2 sets of contact details per dataset. One set of contact details should be used for Freedom of Information (FOI) requests only.
 
-You can edit the dataset information anytime after it’s published.
+You can edit the dataset information after it’s published.
 
-Once you have added information about the dataset, you can add the dataset itself.
+Once you have added information about the dataset, you can add the data itself.
 
 1. Select **Add new resource**.
 1. Complete the fields.
@@ -41,14 +41,14 @@ Local authorities must publish senior staff data in a [different format](http://
 
 You must publish the data 4 times a year. Take a ‘snapshot’ of the roles on:
 
-- 31st March to be published by 30th April
-- 30th June to be published by 31st July
-- 30th September to be published by 30th October
-- 31st December to be published by 31st January
+- 31 March to be published by 30 April
+- 30 June to be published by 31 July
+- 30 September to be published by 30 October
+- 31 December to be published by 31 January
 
 ### What to include
 
-You must fill in the [standard organogram template](https://ckan.publishing.service.gov.uk/publisher-files/Blank_Organogram_Template_latest.xls) with the details of your department's  Senior Civil Service (SCS) pay band 1 and 2 employees.
+You must fill in the [standard organogram template](https://ckan.publishing.service.gov.uk/publisher-files/Blank_Organogram_Template_latest.xls) with the details of your department's Senior Civil Service (SCS) pay band 1 and 2 employees.
 
 ### Publish an organogram dataset
 
@@ -78,7 +78,7 @@ If your organisation already has an organogram dataset, you should add all new o
 1. Select the dataset.
 1. Select **Manage**.
 1. Select **Add data**.
-1. Select **Add new resource**.  
+1. Select **Add new resource**.
 1. Link or upload the data.
 1. Select **Publish**.
 
@@ -92,11 +92,11 @@ Central and local government bodies (including NHS) must publish the details of 
 
 Central government must publish spend data one month in arrears. HM Treasury provides [advice on publishing spend over £25,000](https://www.gov.uk/government/publications/guidance-for-publishing-spend-over-25000), including templates and published examples.
 
-Local government must publish information every month or as soon as it becomes available. The [local government transparency code](https://www.gov.uk/government/publications/local-government-transparency-code-2015) explains what local authorities should publish and when.  
+Local government must publish information every month or as soon as it becomes available. The [local government transparency code](https://www.gov.uk/government/publications/local-government-transparency-code-2015) explains what local authorities should publish and when.
 
 ### Add new spend data
 
-To add a new dataset, sign into the [Data Publisher](https://ckan.publishing.service.gov.uk/).  
+To add a new dataset, sign into the [Data Publisher](https://ckan.publishing.service.gov.uk/).
 
 1. Find the dataset you want to update.
 1. Select **Manage**.

--- a/source/documentation/publish_and_manage_data/harvest_or_add_data.md
+++ b/source/documentation/publish_and_manage_data/harvest_or_add_data.md
@@ -3,8 +3,8 @@
 You can publish datasets to data.gov.uk by:
 
 * using software to [harvest datasets](harvest_data/#harvest-data)
-* [adding datasets manually](add_data/#add-data-manually) using a form
+* [adding datasets manually](add_data/#add-data-manually)
 
-Harvesting means using software built by data.gov.uk, known as a ‘harvester’, to collect datasets from your website and publish them on data.gov.uk. Using the harvester lets you publish more than one dataset at once. You can also schedule harvests to keep data.gov.uk up to date.
+Harvesting means using software, known as a ‘harvester’, to collect datasets from your website and publish them on data.gov.uk. Using the harvester lets you publish more than one dataset at once. You can also schedule harvests.
 
 >You must harvest [Location/INSPIRE data](inspire/#inspire).

--- a/source/documentation/publish_and_manage_data/inspire.md
+++ b/source/documentation/publish_and_manage_data/inspire.md
@@ -26,10 +26,6 @@ The INSPIRE legislation requires most geo-spatial data to be published according
 * metadata records
 * storing data in a GIS (Geographic Information System)
 
-### Metadata records
-
-Metadata records are created at the [UK Location Metadata Editor website](https://locationmde.data.gov.uk/). You fill in the web form to create each record and the website publishes them at a 'WAF service' which data.gov.uk harvests. Geographical software is also required to provide the data to users in a way that fulfils the INSPIRE 'View' and 'Download' requirements. For more information, consult the [User Guide to the UK Location Metadata Editor](https://data.gov.uk/sites/default/files/library/Metadata%20Editor%20User%20Guide.pdf)
-
 ### Geographic Information System (GIS)
 
 You can choose to store data in a GIS (Geographic Information System). This is common for departments and local authorities that have an established geo-spatial data capability. The most commonly used GIS for data.gov.uk is the open source [GeoNetwork](http://geonetwork-opensource.org/), and commercial ones such as ArcGIS are also in use. The GIS provides a 'WMS service' for users to preview the data and 'WFS service' or 'Atom feed' for users to download the data. The GIS also publishes the metadata records for the datasets at a 'CSW service', which data.gov.uk is then configured to harvest from.
@@ -39,10 +35,3 @@ You can choose to store data in a GIS (Geographic Information System). This is c
 Getting your metadata records into data.gov.uk is done by [setting up a data.gov.uk 'harvester'](../harvest_data). You should run the harvester regularly, to ensure that data.gov.uk stays in sync when the publisher updates the records.
 
 Occasionally publishers have made the mistake of using an existing record as a template and simply using a text editor to change the key fields. The main problem with this is that you need to generate a new `gmd:fileIdentifier`, or data.gov.uk will harvest it and overwrite the record that was the template! To generate a new UUID (universally unique identifier) for this field, just visit <https://www.uuidgenerator.net/>.
-
-## Map preview
-
-In order to show the map preview, and the link to the map preview, the metadata needs to:
-
-- Follow the [WMS](https://en.wikipedia.org/wiki/Web_Map_Service) protocol version 1.3.0
-- Have resource type set to `service` and not `dataset`

--- a/source/documentation/publish_and_manage_data/managing_published_data.md
+++ b/source/documentation/publish_and_manage_data/managing_published_data.md
@@ -5,9 +5,9 @@ Once you have published a dataset, you can amend its metadata such as the descri
 1. Sign into the [Data Publisher](https://ckan.publishing.service.gov.uk/) and find the dataset you want to amend.
 1. Select **Manage**.
 
-You can then either edit the metadata for the dataset or select **Add data** to add additional information to add new data to an existing dataset.
+You can then either edit the metadata for the dataset or select **Add data** to add new data to an existing dataset.
 
-Do not create new datasets for data you publish regularly, for example monthly spend data. Instead, create one dataset and add new data to it. This will help users find all monthly datasets published together rather than having to search through a large number of similar datasets.
+Do not create new datasets for data you publish regularly, for example monthly spend data. Instead, create a single dataset and add new data to it. This will help users find all monthly datasets published together rather than having to search through a large number of similar datasets.
 
 ## Unpublishing data
 
@@ -18,4 +18,4 @@ However, you may want to remove datasets that are:
 * duplicates - if there are 2 datasets covering the same data
 * test datasets - if you’ve accidentally published some trial data
 
-Only the data.gov.uk team can delete a dataset. If you want to delete a dataset, [send us a data request](https://data.gov.uk/support).
+Only the data.gov.uk team can delete a dataset. If you want to delete a dataset, [send us a request](https://data.gov.uk/support).


### PR DESCRIPTION
Some general tidyups to make the guidance clearer plus:

- removed mention of the UK Location Metadata Editor which was retired by DEFRA in 2022. 
- removed mention of map previews which have also been retired